### PR TITLE
Minor fix to capture Command key instead of Ctrl on Apple Macs.

### DIFF
--- a/remark.search.js
+++ b/remark.search.js
@@ -8,7 +8,16 @@ class RemarkSearch {
     if (options.caseSensitive == null) options.caseSensitive = false;
     if (options.showIcon == null) options.showIcon = false;
     if (options.autoSearch == null) options.autoSearch = true;
-	if (options.slideshow != null) this.slideshow = options.slideshow;
+	if (options.slideshow != null) 
+	{
+		// Passing slideshow object as part of the options
+		this.slideshow = options.slideshow;
+	}
+	else
+	{
+		// Original behaviour, slideshow is a global var
+		this.slideshow = slideshow;
+	}
 
     this.options = options;
 

--- a/remark.search.js
+++ b/remark.search.js
@@ -70,7 +70,12 @@ class RemarkSearch {
   setUpKeyListener() {
     let self = this;
     document.addEventListener('keydown', function(event) {
-      if (event.ctrlKey && event.key == 'f') {
+  	  const isMac = navigator.platform.toUpperCase().indexOf('MAC')>=0;
+	  
+      if (
+  		  ( isMac && event.metaKey || !isMac && event.ctrlKey ) 
+  		  && event.key == 'f'
+  	  ) {
         event.preventDefault();
         self.openSearch();
         return false;

--- a/remark.search.js
+++ b/remark.search.js
@@ -8,6 +8,7 @@ class RemarkSearch {
     if (options.caseSensitive == null) options.caseSensitive = false;
     if (options.showIcon == null) options.showIcon = false;
     if (options.autoSearch == null) options.autoSearch = true;
+	if (options.slideshow != null) this.slideshow = options.slideshow;
 
     this.options = options;
 
@@ -70,12 +71,13 @@ class RemarkSearch {
   setUpKeyListener() {
     let self = this;
     document.addEventListener('keydown', function(event) {
-  	  const isMac = navigator.platform.toUpperCase().indexOf('MAC')>=0;
+		
+	  const isMac = navigator.platform.toUpperCase().indexOf('MAC')>=0;
 	  
       if (
-  		  ( isMac && event.metaKey || !isMac && event.ctrlKey ) 
-  		  && event.key == 'f'
-  	  ) {
+		  ( isMac && event.metaKey || !isMac && event.ctrlKey ) 
+		  && event.key == 'f'
+	  ) {
         event.preventDefault();
         self.openSearch();
         return false;
@@ -116,7 +118,7 @@ class RemarkSearch {
     let self = this;
     let input = this.div.querySelector('form input');
     input.addEventListener('focus', function(event) {
-      slideshow.pause();
+      self.slideshow.pause();
     });
     input.addEventListener('blur', function(event) {
       slideshow.resume();
@@ -237,8 +239,8 @@ class RemarkSearch {
       index++;
     };
 
-    if (slideshow.getCurrentSlideIndex() + 1 != index)
-      slideshow.gotoSlide(index);
+    if (self.slideshow.getCurrentSlideIndex() + 1 != index)
+      self.slideshow.gotoSlide(index);
 
     return false;
   }


### PR DESCRIPTION
The script will now detect Command + F on an Apple Mac or Ctrl + F on all other OS's to bring up the search box.